### PR TITLE
Feature/kaleb coberly/issue 24/move tests in

### DIFF
--- a/src/comb_utils/lib/api_callers.py
+++ b/src/comb_utils/lib/api_callers.py
@@ -39,7 +39,7 @@ class BaseCaller:
                 def _set_url(self):
                     self._url = "https://example.com/public/v0.2b/"
 
-                def _get_API_key(self) -> str:
+                def _get_API_key(self) -> str | None:
                     # Wrap your own API key retrieval function here.
                     return my_custom_key_retrieval_function()
 
@@ -113,17 +113,6 @@ class BaseCaller:
     @typechecked
     def _set_url(self) -> None:
         """Set the URL for the API call.
-
-        Raises:
-            NotImplementedError: If not implemented in child class.
-        """
-        raise NotImplementedError
-
-    # TODO: bfb_delivery issue 59, comb_utils issue 24: Return "" for no-key API calls?
-    @abstractmethod
-    @typechecked
-    def _get_API_key(self) -> str:
-        """Get the API key.
 
         Raises:
             NotImplementedError: If not implemented in child class.
@@ -206,6 +195,14 @@ class BaseCaller:
             raise ValueError(
                 f"Unexpected response {self._response.status_code}:\n{response_dict}"
             )
+
+    @typechecked
+    def _get_API_key(self) -> str | None:
+        """Get the API key.
+
+        Defaults to None, but can be overridden in child class.
+        """
+        return None
 
     @typechecked
     def _handle_429(self) -> None:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,15 @@
+"""Conftest for unit tests."""
+
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+from typeguard import typechecked
+
+
+@pytest.fixture(autouse=True)
+@typechecked
+def mock_sleep() -> Iterator[None]:
+    """Mock `time.sleep` to avoid waiting in tests."""
+    with patch("comb_utils.lib.api_callers.sleep"):
+        yield

--- a/tests/unit/test_api_callers.py
+++ b/tests/unit/test_api_callers.py
@@ -1,0 +1,42 @@
+"""A test suite for the API callers module."""
+
+from typing import Any, Final
+from unittest.mock import Mock, patch
+
+import pytest
+from typeguard import typechecked
+
+from comb_utils import BaseCaller, BaseDeleteCaller, BaseGetCaller, BasePostCaller
+
+_CALLER_DICT: Final[dict[str, type[BaseCaller]]] = {
+    "get": BaseGetCaller,
+    "post": BasePostCaller,
+    "delete": BaseDeleteCaller,
+}
+
+
+@pytest.mark.parametrize("request_type", ["get", "post", "delete"])
+@typechecked
+def test_key_call(request_type: str) -> None:
+    """Test `call_api` handling of different HTTP responses, including retries."""
+
+    class MockCaller(_CALLER_DICT[request_type]):
+        """Minimal concrete subclass of BaseCaller for testing."""
+
+        def _set_url(self) -> None:
+            """Set a dummy test URL."""
+            self._url = "https://example.com/api/test"
+
+    response_sequence: list[dict[str, Any]] = [
+        {"json.return_value": {"data": [1, 2, 3]}, "status_code": 200}
+    ]
+
+    with patch(f"requests.{request_type}") as mock_request:
+        mock_request.side_effect = [Mock(**resp) for resp in response_sequence]
+        mock_caller = MockCaller()
+
+        with patch.object(
+            mock_caller, "_get_API_key", wraps=mock_caller._get_API_key
+        ) as spy_handle_get_API_key:
+            mock_caller.call_api()
+            spy_handle_get_API_key.assert_called_once()

--- a/tests/unit/test_api_callers.py
+++ b/tests/unit/test_api_callers.py
@@ -18,7 +18,7 @@ _CALLER_DICT: Final[dict[str, type[BaseCaller]]] = {
 @pytest.mark.parametrize("request_type", ["get", "post", "delete"])
 @typechecked
 def test_key_call(request_type: str) -> None:
-    """Test `call_api` handling of different HTTP responses, including retries."""
+    """Test `call_api` calls `_get_API_key`."""
 
     class MockCaller(_CALLER_DICT[request_type]):
         """Minimal concrete subclass of BaseCaller for testing."""

--- a/tests/unit/test_api_callers.py
+++ b/tests/unit/test_api_callers.py
@@ -1,9 +1,11 @@
 """A test suite for the API callers module."""
 
+from contextlib import AbstractContextManager, nullcontext
 from typing import Any, Final
 from unittest.mock import Mock, patch
 
 import pytest
+import requests
 from typeguard import typechecked
 
 from comb_utils import BaseCaller, BaseDeleteCaller, BaseGetCaller, BasePostCaller
@@ -40,3 +42,119 @@ def test_key_call(request_type: str) -> None:
         ) as spy_handle_get_API_key:
             mock_caller.call_api()
             spy_handle_get_API_key.assert_called_once()
+
+
+@pytest.mark.parametrize("request_type", ["get", "post", "delete"])
+@pytest.mark.parametrize(
+    "response_sequence, expected_result, error_context",
+    [
+        (
+            [{"json.return_value": {"data": [1, 2, 3]}, "status_code": 200}],
+            {"data": [1, 2, 3]},
+            nullcontext(),
+        ),
+        ([{"json.return_value": {}, "status_code": 204}], {}, nullcontext()),
+        (
+            [
+                {
+                    "json.return_value": {},
+                    "status_code": 429,
+                    "raise_for_status.side_effect": requests.exceptions.HTTPError,
+                },
+                {"json.return_value": {"data": [5, 6]}, "status_code": 200},
+            ],
+            {"data": [5, 6]},
+            nullcontext(),
+        ),
+        (
+            [
+                {
+                    "json.return_value": {},
+                    "status_code": 598,
+                    "raise_for_status.side_effect": requests.exceptions.Timeout,
+                },
+                {"json.return_value": {"data": [7, 8]}, "status_code": 200},
+            ],
+            {"data": [7, 8]},
+            nullcontext(),
+        ),
+        (
+            [
+                {
+                    "status_code": 400,
+                    "raise_for_status.side_effect": requests.exceptions.HTTPError,
+                }
+            ],
+            None,
+            pytest.raises(requests.exceptions.HTTPError, match="Got 400 response"),
+        ),
+        (
+            [
+                {
+                    "json.return_value": {},
+                    "status_code": 429,
+                    "raise_for_status.side_effect": requests.exceptions.HTTPError,
+                },
+                {
+                    "status_code": 400,
+                    "raise_for_status.side_effect": requests.exceptions.HTTPError,
+                },
+            ],
+            None,
+            pytest.raises(requests.exceptions.HTTPError, match="Got 400 response"),
+        ),
+        (
+            [
+                {
+                    "json.return_value": {},
+                    "status_code": 598,
+                    "raise_for_status.side_effect": requests.exceptions.Timeout,
+                },
+                {
+                    "status_code": 400,
+                    "raise_for_status.side_effect": requests.exceptions.HTTPError,
+                },
+            ],
+            None,
+            pytest.raises(requests.exceptions.HTTPError, match="Got 400 response"),
+        ),
+    ],
+)
+@typechecked
+def test_base_caller_response_handling(
+    request_type: str,
+    response_sequence: list[dict[str, Any]],
+    expected_result: dict[str, Any] | None,
+    error_context: AbstractContextManager,
+) -> None:
+    """Test `call_api` handling of different HTTP responses, including retries."""
+
+    class MockCaller(_CALLER_DICT[request_type]):
+        """Minimal concrete subclass of BaseCaller for testing."""
+
+        def _set_url(self) -> None:
+            """Set a dummy test URL."""
+            self._url = "https://example.com/api/test"
+
+    with patch(f"requests.{request_type}") as mock_request:
+        mock_request.side_effect = [Mock(**resp) for resp in response_sequence]
+        mock_caller = MockCaller()
+
+        with patch.object(
+            mock_caller, "_handle_429", wraps=mock_caller._handle_429
+        ) as spy_handle_429, patch.object(
+            mock_caller, "_handle_timeout", wraps=mock_caller._handle_timeout
+        ) as spy_handle_timeout:
+
+            with error_context:
+                mock_caller.call_api()
+
+                assert mock_caller.response_json == expected_result
+
+                if any(resp["status_code"] == 429 for resp in response_sequence):
+                    spy_handle_429.assert_called_once()
+
+                if any(resp["status_code"] == 598 for resp in response_sequence):
+                    spy_handle_timeout.assert_called_once()
+
+                assert mock_request.call_count == len(response_sequence)


### PR DESCRIPTION
Move base api_callers tests over from `bfb_delivery`.
Updates `_get_API_key` to default to None instead of being an abstract method. (Allowed for simpler test transfer, and accommodates broader use of the base classes off the shelf where no API key is needed.)