### PR TITLE
Bugfix/kaleb coberly/pin flake8 black

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ doc =
 qc =
     bandit
     black
-    black[jupyter]
     flake8
     flake8-annotations
     flake8-bandit

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = comb_utils
-version = 0.2.14
+version = 0.2.15
 description = Handy utils for Python projects.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,12 +38,12 @@ doc =
 
 qc =
     bandit
-    black<25.9.0
+    black
     black[jupyter]
     flake8
     flake8-annotations
     flake8-bandit
-    flake8-black
+    flake8-black>=0.4.0
     flake8-bugbear
     flake8-docstrings
     flake8-isort


### PR DESCRIPTION
Pins to `flake8-black` release that pins `black` to avoid breaking release.
Also removes unnecessary `flake8-black[jupyter]`.