### PR TITLE
Bugfix/kaleb coberly/make defaults optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,9 @@ __pycache__/
 # *_test_report.xml
 
 # Docs
-docs/_build/
 comb_utils*.rst
+docs/.DS_Store
+docs/_build/
 docs/modules.rst
 docs/**/*.pickle
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,38 +1,11 @@
 # Packaging
-# .Python
-# build/
-# develop-eggs/
 dist/
-# downloads/
-# eggs/
-# .eggs/
-# lib64/
-# parts/
-# sdist/
-# var/
-# pip-wheel-metadata/
-# share/python-wheels/
 *.egg-info/
-# .installed.cfg
-# *.egg
-# MANIFEST
-
-# Installer
-# pip-log.txt
-# pip-delete-this-directory.txt
 
 # Test coverage
-# cov_report
-# .coverage
 .coverage.*
-# .cache
-# coverage.xml
-# *.cover
-# *.py,cover
 __pycache__/
 .pytest_cache/
-# cover/
-# *_test_report.xml
 
 # Docs
 comb_utils*.rst
@@ -41,28 +14,8 @@ docs/_build/
 docs/modules.rst
 docs/**/*.pickle
 
-# Env
 .env
-# .venv
-# env/
-# venv/
-# ENV/
-# env.bak
-# venv.bak
-# *.sif
 
-# pytype
 .pytype/
 
-#pycharm
-# .idea/*
-
-# VS Code
-# .vscode
-# *.mustache
-
-# MacOS
-# .DS_Store
-
-# Workflows
 .github/workflows/CI_CD_act.yml

--- a/docs/docstring.rst
+++ b/docs/docstring.rst
@@ -24,10 +24,6 @@ Example usage:
             "a": "The first number. Must be greater than 0.",
             "b": "The second number. Must be less than 100."
         },
-        defaults={
-            "a": 1,
-            "b": 99
-        },
         returns=["The sum of the two numbers."],
         error_docstrings=[
             ErrorDocString(
@@ -39,6 +35,10 @@ Example usage:
                 docstring="If `b` is greater than 100."
             )
         ]
+        defaults={
+            "a": 1,
+            "b": 99
+        },
     )
 
 Now you can use :code:`docstring.api_docstring` in your functions, and :code:`docstring.cli_docstring` and :code:`args` in your Click commands.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = comb_utils
-version = 0.5.0
+version = 0.5.1
 description = Handy utils for Python projects.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/comb_utils/lib/docs.py
+++ b/src/comb_utils/lib/docs.py
@@ -34,9 +34,9 @@ class DocString:
     Args:
             opening: The opening docstring.
             args: Argument names and their docstrings.
-            defaults: The parameter defaults.
             raises: Objects holding error types with their docstrings.
             returns: The returns docstrings.
+            defaults: The parameter defaults. ``None`` casts to empty ``dict``.
     """
 
     opening: str = ""

--- a/src/comb_utils/lib/docs.py
+++ b/src/comb_utils/lib/docs.py
@@ -43,7 +43,7 @@ class DocString:
     args: dict[str, str] = {}
     raises: list[ErrorDocString] = []
     returns: list[str] = []
-    defaults: dict[str, Any] | None = None
+    defaults: dict[str, Any] = {}
 
     @typechecked
     def __init__(
@@ -59,7 +59,7 @@ class DocString:
         self.args = args
         self.raises = raises
         self.returns = returns
-        self.defaults = defaults
+        self.defaults = defaults if defaults is not None else {}
 
         return
 

--- a/src/comb_utils/lib/docs.py
+++ b/src/comb_utils/lib/docs.py
@@ -41,25 +41,25 @@ class DocString:
 
     opening: str = ""
     args: dict[str, str] = {}
-    defaults: dict[str, Any] = {}
     raises: list[ErrorDocString] = []
     returns: list[str] = []
+    defaults: dict[str, Any] | None = None
 
     @typechecked
     def __init__(
         self,
         opening: str,
         args: dict[str, str],
-        defaults: dict[str, Any],
         raises: list[ErrorDocString],
         returns: list[str],
+        defaults: dict[str, Any] | None = None,
     ) -> None:
         """Initialize the docstring parts."""
         self.opening = opening
         self.args = args
-        self.defaults = defaults
         self.raises = raises
         self.returns = returns
+        self.defaults = defaults
 
         return
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -14,7 +14,6 @@ from comb_utils import DocString, ErrorDocString
             DocString(
                 opening="Test opening",
                 args={"arg1": "arg1 docstring", "arg2": "arg2 docstring"},
-                defaults={},
                 raises=[
                     ErrorDocString(error_type="Error1", docstring="Error1 docstring"),
                     ErrorDocString(error_type="Error2", docstring="Error2 docstring"),
@@ -32,7 +31,6 @@ from comb_utils import DocString, ErrorDocString
             DocString(
                 opening="Test opening",
                 args={},
-                defaults={},
                 raises=[ErrorDocString(error_type="Error1", docstring="Error1 docstring")],
                 returns=["return1", "return2"],
             ),
@@ -46,7 +44,6 @@ from comb_utils import DocString, ErrorDocString
             DocString(
                 opening="Test opening",
                 args={"arg1": "arg1 docstring", "arg2": "arg2 docstring"},
-                defaults={},
                 raises=[],
                 returns=["return1", "return2"],
             ),
@@ -60,7 +57,6 @@ from comb_utils import DocString, ErrorDocString
             DocString(
                 opening="Test opening",
                 args={"arg1": "arg1 docstring", "arg2": "arg2 docstring"},
-                defaults={},
                 raises=[ErrorDocString(error_type="Error1", docstring="Error1 docstring")],
                 returns=[],
             ),
@@ -84,7 +80,6 @@ def test_api_docstring(docstring: DocString, expected_docstring: str) -> None:
             DocString(
                 opening="Test opening",
                 args={"arg1": "arg1 docstring", "arg2": "arg2 docstring"},
-                defaults={},
                 raises=[
                     ErrorDocString(error_type="Error1", docstring="Error1 docstring"),
                     ErrorDocString(error_type="Error2", docstring="Error2 docstring"),
@@ -101,7 +96,6 @@ def test_api_docstring(docstring: DocString, expected_docstring: str) -> None:
             DocString(
                 opening="Test opening",
                 args={},
-                defaults={},
                 raises=[ErrorDocString(error_type="Error1", docstring="Error1 docstring")],
                 returns=["return1", "return2"],
             ),
@@ -113,7 +107,6 @@ def test_api_docstring(docstring: DocString, expected_docstring: str) -> None:
             DocString(
                 opening="Test opening",
                 args={"arg1": "arg1 docstring", "arg2": "arg2 docstring"},
-                defaults={},
                 raises=[],
                 returns=["return1", "return2"],
             ),
@@ -123,7 +116,6 @@ def test_api_docstring(docstring: DocString, expected_docstring: str) -> None:
             DocString(
                 opening="Test opening",
                 args={"arg1": "arg1 docstring", "arg2": "arg2 docstring"},
-                defaults={},
                 raises=[ErrorDocString(error_type="Error1", docstring="Error1 docstring")],
                 returns=[],
             ),
@@ -144,12 +136,12 @@ Dummy function which concatenates two input strings and returns the output.
         "arg1": "The first string.",
         "arg2": "The second string.",
     },
+    raises=[],
+    returns=["The concatenated string."],
     defaults={
         "arg1": "Test ",
         "arg2": "Passed!",
     },
-    raises=[],
-    returns=["The concatenated string."],
 )
 
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -128,32 +128,31 @@ def test_cli_docstring(docstring: DocString, expected_docstring: str) -> None:
     assert docstring.cli_docstring == expected_docstring
 
 
-DUMMY_FUNCTION: Final = DocString(
-    opening="""
-Dummy function which concatenates two input strings and returns the output.
-""",
-    args={
-        "arg1": "The first string.",
-        "arg2": "The second string.",
-    },
-    raises=[],
-    returns=["The concatenated string."],
-    defaults={
-        "arg1": "Test ",
-        "arg2": "Passed!",
-    },
-)
-
-
-def dummy_function(
-    arg1: str = DUMMY_FUNCTION.defaults["arg1"], arg2: str = DUMMY_FUNCTION.defaults["arg2"]
-) -> str:
-    """Dummy function which concatenates two input strings and returns the output."""
-    result = arg1 + arg2
-
-    return result
-
-
 def test_defaults() -> None:
     """Test the defaults attribute of the DocString class."""
+    DUMMY_DOCSTRING: Final[DocString] = DocString(
+        opening="""
+    Dummy function which concatenates two input strings and returns the output.
+    """,
+        args={
+            "arg1": "The first string.",
+            "arg2": "The second string.",
+        },
+        raises=[],
+        returns=["The concatenated string."],
+        defaults={
+            "arg1": "Test ",
+            "arg2": "Passed!",
+        },
+    )
+
+    def dummy_function(
+        arg1: str = DUMMY_DOCSTRING.defaults["arg1"],
+        arg2: str = DUMMY_DOCSTRING.defaults["arg2"],
+    ) -> str:
+        """Dummy function which concatenates two input strings and returns the output."""
+        result = arg1 + arg2
+
+        return result
+
     assert dummy_function() == "Test Passed!"


### PR DESCRIPTION
Makes `DocStrings.defaults` optional.
Addresses https://github.com/crickets-and-comb/comb_utils/issues/23#issue-2939952137

Also updates `.gitignore`.