### PR TITLE
nltk develop

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,8 @@ package_dir=
     =src
 packages=find:
 install_requires =
+    # Until nltk 3.9.3 is released: https://github.com/nltk/nltk/pull/3503
+    nltk @ git+https://github.com/nltk/nltk.git@develop
     requests>=2.32.3,<3.0.0
     typeguard>=4.4.4,<5.0.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = comb_utils
-version = 0.6.3
+version = 0.6.4
 description = Handy utils for Python projects.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Partially addresses https://github.com/crickets-and-comb/shared/issues/152
Pins to `nltk@develop` until 3.9.3 released to address CVE-2025-14009.
Updates `shared` Git submodule to ignore for now.